### PR TITLE
Fixed synchronized lists and maps for order by query race condition

### DIFF
--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/FeedResponseDiagnostics.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/FeedResponseDiagnostics.java
@@ -28,7 +28,7 @@ public class FeedResponseDiagnostics {
     private static final Logger LOGGER = LoggerFactory.getLogger(FeedResponseDiagnostics.class);
     private Map<String, QueryMetrics> queryMetricsMap;
     private QueryInfo.QueryPlanDiagnosticsContext diagnosticsContext;
-    private List<ClientSideRequestStatistics> clientSideRequestStatisticsList;
+    private final List<ClientSideRequestStatistics> clientSideRequestStatisticsList;
 
     public FeedResponseDiagnostics(Map<String, QueryMetrics> queryMetricsMap) {
         this.queryMetricsMap = queryMetricsMap;

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/FeedResponseDiagnostics.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/FeedResponseDiagnostics.java
@@ -8,7 +8,6 @@ import com.azure.cosmos.implementation.query.metrics.QueryMetricsTextWriter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
-
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/FeedResponseDiagnostics.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/FeedResponseDiagnostics.java
@@ -8,6 +8,7 @@ import com.azure.cosmos.implementation.query.metrics.QueryMetricsTextWriter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
+
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/query/OrderByDocumentProducer.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/query/OrderByDocumentProducer.java
@@ -62,7 +62,7 @@ class OrderByDocumentProducer<T extends Resource> extends DocumentProducer<T> {
         return replacementProducers.collectList().flux().flatMap(documentProducers -> {
             RequestChargeTracker tracker = new RequestChargeTracker();
             Map<String, QueryMetrics> queryMetricsMap = new HashMap<>();
-            List<ClientSideRequestStatistics> clientSideRequestStatisticsList = new ArrayList<>();
+            List<ClientSideRequestStatistics> clientSideRequestStatisticsList = Collections.synchronizedList(new ArrayList<>());
             return OrderByUtils.orderedMerge(resourceType, consumeComparer, tracker, documentProducers, queryMetricsMap,
                     targetRangeToOrderByContinuationTokenMap, clientSideRequestStatisticsList)
                     .map(orderByQueryResult -> resultPageFrom(tracker, orderByQueryResult));

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/query/OrderByDocumentQueryExecutionContext.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/query/OrderByDocumentQueryExecutionContext.java
@@ -204,7 +204,10 @@ public class OrderByDocumentQueryExecutionContext<T extends Resource>
                                               String filter) {
         for (Map.Entry<FeedRangeEpkImpl, OrderByContinuationToken> entry :
             rangeToTokenMapping.entrySet()) {
-            targetRangeToOrderByContinuationTokenMap.put(entry.getKey(), entry.getValue());
+            //  only put the entry if the value is not null
+            if (entry.getValue() != null) {
+                targetRangeToOrderByContinuationTokenMap.put(entry.getKey(), entry.getValue());
+            }
             Map<FeedRangeEpkImpl, String> partitionKeyRangeToContinuationToken = new HashMap<FeedRangeEpkImpl, String>();
             partitionKeyRangeToContinuationToken.put(entry.getKey(), null);
             super.initialize(collectionRid,

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/query/OrderByDocumentQueryExecutionContext.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/query/OrderByDocumentQueryExecutionContext.java
@@ -60,7 +60,7 @@ public class OrderByDocumentQueryExecutionContext<T extends Resource>
     private final OrderbyRowComparer<T> consumeComparer;
     private final RequestChargeTracker tracker;
     private final ConcurrentMap<String, QueryMetrics> queryMetricMap;
-    List<ClientSideRequestStatistics> clientSideRequestStatisticsList;
+    private final List<ClientSideRequestStatistics> clientSideRequestStatisticsList;
     private Flux<OrderByRowResult<T>> orderByObservable;
     private final Map<FeedRangeEpkImpl, OrderByContinuationToken> targetRangeToOrderByContinuationTokenMap;
 
@@ -84,8 +84,8 @@ public class OrderByDocumentQueryExecutionContext<T extends Resource>
         this.consumeComparer = consumeComparer;
         this.tracker = new RequestChargeTracker();
         this.queryMetricMap = new ConcurrentHashMap<>();
-        this.clientSideRequestStatisticsList = new ArrayList<>();
-        targetRangeToOrderByContinuationTokenMap = new HashMap<>();
+        this.clientSideRequestStatisticsList = Collections.synchronizedList(new ArrayList<>());
+        targetRangeToOrderByContinuationTokenMap = new ConcurrentHashMap<>();
     }
 
     public static <T extends Resource> Flux<IDocumentQueryExecutionComponent<T>> createAsync(

--- a/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/rx/OrderbyDocumentQueryTest.java
+++ b/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/rx/OrderbyDocumentQueryTest.java
@@ -16,7 +16,6 @@ import com.azure.cosmos.implementation.InternalObjectNode;
 import com.azure.cosmos.implementation.PartitionKeyRange;
 import com.azure.cosmos.implementation.Resource;
 import com.azure.cosmos.implementation.ResourceValidator;
-import com.azure.cosmos.implementation.RetryAnalyzer;
 import com.azure.cosmos.implementation.Utils;
 import com.azure.cosmos.implementation.Utils.ValueHolder;
 import com.azure.cosmos.implementation.query.CompositeContinuationToken;
@@ -24,7 +23,6 @@ import com.azure.cosmos.implementation.query.OrderByContinuationToken;
 import com.azure.cosmos.implementation.query.QueryItem;
 import com.azure.cosmos.implementation.routing.Range;
 import com.azure.cosmos.models.CosmosContainerProperties;
-import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.FeedResponse;
 import com.azure.cosmos.models.IncludedPath;
@@ -74,19 +72,18 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
         super(clientBuilder);
     }
 
-    @Test(groups = { "simple" }, timeOut = TIMEOUT, dataProvider = "queryMetricsArgProvider")
-    public void queryDocumentsValidateContent(Boolean qmEnabled) throws Exception {
-        InternalObjectNode expectedDocument = createdDocuments.get(0);
+    @Test(groups = { "simple" }, timeOut = TIMEOUT)
+    public void queryDocumentsValidateContent() throws Exception {
+        // removes undefined
+        InternalObjectNode expectedDocument = createdDocuments
+            .stream()
+            .filter(d -> ModelBridgeInternal.getMapFromJsonSerializable(d).containsKey("propInt"))
+            .min(Comparator.comparing(o -> String.valueOf(o.get("propInt")))).get();
 
-        String query = String.format("SELECT * from root r where r.propStr = '%s'"
-            + " ORDER BY r.propInt"
-            , ModelBridgeInternal.getStringFromJsonSerializable(expectedDocument,"propStr"));
+        String query = String.format("SELECT * from root r where r.propInt = %d ORDER BY r.propInt ASC"
+            , ModelBridgeInternal.getIntFromJsonSerializable(expectedDocument,"propInt"));
 
         CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
-
-        if (qmEnabled != null) {
-            options.setQueryMetricsEnabled(qmEnabled);
-        }
 
         CosmosPagedFlux<InternalObjectNode> queryObservable = createdCollection.queryItems(query, options, InternalObjectNode.class);
 
@@ -104,7 +101,7 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
                 .validateAllResources(resourceIDToValidator)
                 .totalRequestChargeIsAtLeast(numberOfPartitions * minQueryRequestChargePerPartition)
                 .allPagesSatisfy(new FeedResponseValidator.Builder<InternalObjectNode>().hasRequestChargeHeader().build())
-                .hasValidQueryMetrics(qmEnabled)
+                .hasValidQueryMetrics(true)
                 .build();
 
         validateQuerySuccess(queryObservable.byPage(), validator);
@@ -135,7 +132,7 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
 
     @Test(groups = { "simple" }, timeOut = TIMEOUT, dataProvider = "sortOrder")
     public void queryOrderBy(String sortOrder) throws Exception {
-        String query = String.format("SELECT * FROM r ORDER BY r.propInt %s", sortOrder);
+        String query = String.format("SELECT * FROM r where r.propInt != null ORDER BY r.propInt %s", sortOrder);
         CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
 
         int pageSize = 3;
@@ -162,7 +159,7 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
 
     @Test(groups = {"simple"}, timeOut = TIMEOUT, dataProvider = "sortOrder")
     public void queryOrderByWithValue(String sortOrder) throws Exception {
-        String query = String.format("SELECT value r.propInt FROM r ORDER BY r.propInt %s", sortOrder);
+        String query = String.format("SELECT value r.propInt FROM r where r.propInt != null ORDER BY r.propInt %s", sortOrder);
         CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
 
         int pageSize = 3;
@@ -194,7 +191,7 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
 
     @Test(groups = { "simple" }, timeOut = TIMEOUT)
     public void queryOrderByInt() throws Exception {
-        String query = "SELECT * FROM r ORDER BY r.propInt";
+        String query = "SELECT * FROM r where r.propInt != null ORDER BY r.propInt";
         CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
 
         int pageSize = 3;
@@ -217,7 +214,7 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
 
     @Test(groups = { "simple" }, timeOut = TIMEOUT)
     public void queryOrderByString() throws Exception {
-        String query = "SELECT * FROM r ORDER BY r.propStr";
+        String query = "SELECT * FROM r where r.propStr != null ORDER BY r.propStr";
         CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
 
         int pageSize = 3;
@@ -355,7 +352,7 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
 
     @Test(groups = { "simple" }, timeOut = TIMEOUT, dataProvider =  "topValue")
     public void queryOrderWithTop(int topValue) throws Exception {
-        String query = String.format("SELECT TOP %d * FROM r ORDER BY r.propInt", topValue);
+        String query = String.format("SELECT TOP %d * FROM r where r.propInt != null ORDER BY r.propInt", topValue);
         CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
 
         int pageSize = 3;
@@ -401,7 +398,7 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
     public void queryScopedToSinglePartition_StartWithContinuationToken() throws Exception {
         String query = "SELECT * FROM r ORDER BY r.propScopedPartitionInt ASC";
         CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
-        options.setPartitionKey(new PartitionKey("duplicateParitionKeyValue"));
+        options.setPartitionKey(new PartitionKey("duplicatePartitionKeyValue"));
         CosmosPagedFlux<InternalObjectNode> queryObservable = createdCollection.queryItems(query, options, InternalObjectNode.class);
 
         TestSubscriber<FeedResponse<InternalObjectNode>> subscriber = new TestSubscriber<>();
@@ -421,7 +418,7 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
         queryObservable = createdCollection.queryItems(query, options, InternalObjectNode.class);
 
         List<InternalObjectNode> expectedDocs = createdDocuments.stream()
-                                                                .filter(d -> (StringUtils.equals("duplicateParitionKeyValue", ModelBridgeInternal.getStringFromJsonSerializable(d,"mypk"))))
+                                                                .filter(d -> (StringUtils.equals("duplicatePartitionKeyValue", ModelBridgeInternal.getStringFromJsonSerializable(d,"mypk"))))
                                                                 .filter(d -> (ModelBridgeInternal.getIntFromJsonSerializable(d,"propScopedPartitionInt") > 2)).collect(Collectors.toList());
         Integer maxItemCount = ModelBridgeInternal.getMaxItemCountFromQueryRequestOptions(options);
         int expectedPageSize = (expectedDocs.size() + maxItemCount - 1) / maxItemCount;
@@ -486,11 +483,10 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
         	assertThat(OrderByContinuationToken.tryParse("{\"property\" : \"Not a valid Order By Token\"}", outOrderByContinuationToken)).isFalse();
         }
 	}
-    @Test(groups = { "simple" }, timeOut = TIMEOUT * 10, dataProvider = "sortOrder",
-            retryAnalyzer = RetryAnalyzer.class)
+    @Test(groups = { "simple" }, timeOut = TIMEOUT * 10, dataProvider = "sortOrder")
     public void queryDocumentsWithOrderByContinuationTokensInteger(String sortOrder) throws Exception {
         // Get Actual
-        String query = String.format("SELECT * FROM c ORDER BY c.propInt %s", sortOrder);
+        String query = String.format("SELECT * FROM r where r.propInt != null ORDER BY r.propInt %s", sortOrder);
 
         // Get Expected
         Comparator<Integer> order = sortOrder.equals("ASC")?Comparator.naturalOrder():Comparator.reverseOrder();
@@ -531,7 +527,7 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
 
     @Test(groups = {"simple"}, timeOut = TIMEOUT, dataProvider = "sortOrder")
     public void queryOrderByArray(String sortOrder) throws Exception {
-        String query = String.format("SELECT * FROM r ORDER BY r.propArray %s", sortOrder);
+        String query = String.format("SELECT * FROM r where r.propArray != null ORDER BY r.propArray %s", sortOrder);
 
         int pageSize = 3;
         List<InternalObjectNode> results1 = this.queryWithContinuationTokens(query, pageSize);
@@ -545,7 +541,7 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
 
     @Test(groups = {"simple"}, timeOut = TIMEOUT, dataProvider = "sortOrder")
     public void queryOrderByObject(String sortOrder) throws Exception {
-        String query = String.format("SELECT * FROM r ORDER BY r.propObject %s", sortOrder);
+        String query = String.format("SELECT * FROM r where r.propObject != null ORDER BY r.propObject %s", sortOrder);
 
         int pageSize = 3;
         List<InternalObjectNode> results1 = this.queryWithContinuationTokens(query, pageSize);
@@ -590,8 +586,9 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
         List<Map<String, Object>> keyValuePropsList = new ArrayList<>();
         Map<String, Object> props;
         boolean flag = false;
+        final int initialDocumentsSize = 30;
 
-        for(int i = 0; i < 30; i++) {
+        for(int i = 0; i < initialDocumentsSize; i++) {
             props = new HashMap<>();
             props.put("propInt", i);
             props.put("propStr", String.valueOf(i));
@@ -651,10 +648,8 @@ public class OrderbyDocumentQueryTest extends TestSuiteBase {
         for(int i = 0; i < 10; i++) {
             Map<String, Object> p = new HashMap<>();
             p.put("propScopedPartitionInt", i);
-            InternalObjectNode doc = getDocumentDefinition("duplicateParitionKeyValue", UUID.randomUUID().toString(), p);
-            CosmosItemRequestOptions options = new CosmosItemRequestOptions();
+            InternalObjectNode doc = getDocumentDefinition("duplicatePartitionKeyValue", UUID.randomUUID().toString(), p);
             createdDocuments.add(createDocument(createdCollection, doc));
-
         }
 
         numberOfPartitions = CosmosBridgeInternal.getAsyncDocumentClient(client)

--- a/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/rx/TestSuiteBase.java
+++ b/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/rx/TestSuiteBase.java
@@ -1101,6 +1101,11 @@ public class TestSuiteBase extends CosmosAsyncClientTest {
     }
 
     @DataProvider
+    public static Object[][] clientBuildersWithDirectTcpSession() {
+        return clientBuildersWithDirectSession(true, true, Protocol.TCP);
+    }
+
+    @DataProvider
     public static Object[][] simpleClientBuilderGatewaySession() {
         return clientBuildersWithDirectSession(true, true);
     }


### PR DESCRIPTION
* Fixed synchronized lists and maps for order by query race condition.
* No perf difference when running `OrderByQuery` performance benchmark.